### PR TITLE
Fix duplicate error handlers

### DIFF
--- a/backend/routes/generateDiet.js
+++ b/backend/routes/generateDiet.js
@@ -45,11 +45,7 @@ router.post('/', validateInput, async (req, res, next) => {
       code: error.code,
       originalError: error.originalError?.message || error.originalError || null
     });
-
-    res.status(error.status || 500).json({
-      success: false,
-      message: error.message || "Error interno del servidor"
-    });
+    next(error);
   }
 });
 

--- a/backend/routes/metrics.js
+++ b/backend/routes/metrics.js
@@ -58,13 +58,13 @@ const router = express.Router();
  *                       completionTokens:
  *                         type: number
  */
-router.get('/usage', (req, res) => {
+router.get('/usage', (req, res, next) => {
   try {
     const stats = getUsageStats();
     res.json(stats);
   } catch (error) {
     console.error('Error al obtener métricas:', error);
-    res.status(500).json({ error: 'Error al obtener métricas' });
+    next(error);
   }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -110,22 +110,6 @@ app.use((req, res, next) => {
   });
 });
 
-// Manejador de errores global
-app.use((err, req, res, next) => {
-  console.error('Error en el servidor:', {
-    message: err.message,
-    stack: process.env.NODE_ENV === 'development' ? err.stack : undefined,
-    url: req.originalUrl,
-    method: req.method,
-    body: req.body
-  });
-
-  res.status(err.status || 500).json({
-    success: false,
-    error: process.env.NODE_ENV === 'development' ? err.message : 'Error interno del servidor',
-    ...(process.env.NODE_ENV === 'development' && { stack: err.stack })
-  });
-});
 
 const PORT = process.env.PORT || 4000;
 const HOST = process.env.HOST || '0.0.0.0';


### PR DESCRIPTION
## Summary
- remove redundant error handler in `server.js`
- forward route errors using `next`

## Testing
- `npm test` *(fails: no test specified)*
- manual request to `/api/generate`

------
https://chatgpt.com/codex/tasks/task_e_688ccf30b03c832c908c646036ea1bb1