### PR TITLE
Sanitize API key logging

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -16,7 +16,10 @@ const envFile = process.env.NODE_ENV === 'production'
   ? '.env.production' 
   : '.env';
 dotenv.config({ path: path.resolve(__dirname, envFile) });
-console.log("GROQ_API_KEY desde dotenv:", process.env.GROQ_API_KEY || 'NO CARGADA');
+console.log(
+  "GROQ_API_KEY loaded:",
+  process.env.GROQ_API_KEY ? "***" : "NO CARGADA"
+);
 
 console.log('Variables de entorno cargadas en server.js:', {
   PORT: process.env.PORT,


### PR DESCRIPTION
## Summary
- avoid printing the GROQ API key in server startup logs

## Testing
- `npm test --prefix backend` *(fails: no test specified)*
- `npm test --prefix frontend` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688ccee489ac832cb39faf328c0036ef