### PR TITLE
Improve calorie input UX

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
   const { loginWithRedirect, logout, isAuthenticated, isLoading: authLoading, user } = useAuth0();
 
   const [formData, setFormData] = useState({
-    calories: "",
+    calories: "2000",
     mealsPerDay: "3",
     allergies: "",
     preferences: "",
@@ -55,8 +55,8 @@ function App() {
 
   const validateForm = () => {
     const newErrors = {};
-    if (!formData.calories || isNaN(formData.calories) || formData.calories < 1000 || formData.calories > 5000)
-      newErrors.calories = "Introduce entre 1000 y 5000 kcal";
+    if (!formData.calories || isNaN(formData.calories) || formData.calories < 1000 || formData.calories > 10000)
+      newErrors.calories = "Introduce entre 1000 y 10000 kcal";
     if (!formData.mealsPerDay || isNaN(formData.mealsPerDay) || formData.mealsPerDay < 1 || formData.mealsPerDay > 6)
       newErrors.mealsPerDay = "Introduce entre 1 y 6 comidas";
     if (!formData.goal) newErrors.goal = "Selecciona un objetivo";

--- a/frontend/src/components/DietForm.jsx
+++ b/frontend/src/components/DietForm.jsx
@@ -188,51 +188,19 @@ const DietForm = ({
                 <div className="space-y-4">
                 <div className="space-y-2 text-center">
                   <h3 className="text-sm font-medium text-gray-700 mb-2">Calorías diarias</h3>
-                  <div className="relative">
+                  <div className="space-y-2">
+                    <div className="text-xl font-semibold text-gray-900">{formData.calories} kcal</div>
                     <input
-                      type="number"
+                      type="range"
                       name="calories"
-                      value={formData.calories || ''}
-                      onChange={(e) => {
-                        const value = e.target.value;
-                        // Actualizar el valor local inmediatamente
-                        const input = e.target;
-                        if (value === '' || (Number(value) >= 1000 && Number(value) <= 10000)) {
-                          // Actualizar el estado del formulario
-                          handleChange({
-                            target: {
-                              name: 'calories',
-                              value: value === '' ? '' : Math.round(Number(value)).toString()
-                            }
-                          });
-                        } else {
-                          // Si el valor no es válido, mantener el valor anterior
-                          input.value = formData.calories || '';
-                        }
-                      }}
-                      onBlur={(e) => {
-                        // Asegurar que el valor esté dentro del rango al perder el foco
-                        let value = Number(e.target.value);
-                        if (isNaN(value) || value < 1000) value = 2000;
-                        value = Math.max(1000, Math.min(10000, value));
-                        // Actualizar el valor del input directamente
-                        e.target.value = value;
-                        // Actualizar el estado del formulario
-                        handleChange({
-                          target: {
-                            name: 'calories',
-                            value: value.toString()
-                          }
-                        });
-                      }}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg text-center text-xl font-semibold text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                      placeholder="2000"
+                      value={formData.calories || 2000}
+                      onChange={(e) => handleChange({ target: { name: 'calories', value: e.target.value } })}
+                      className="w-full accent-primary-600"
                       min="1000"
                       max="10000"
                       step="50"
                       required
                     />
-                    <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500">kcal</span>
                   </div>
                   <p className="text-xs text-gray-500">
                     <button


### PR DESCRIPTION
## Summary
- preset calories to 2000 by default
- validate calories up to 10,000
- use a slider for calorie selection

## Testing
- `npm test --silent` in `frontend` *(fails: No test files found)*
- `npm test --silent` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cd48a89ec832cbd679787716fa9ef