### PR TITLE
Add generic spinner for app loading

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useAuth0 } from "@auth0/auth0-react";
 import { useState } from "react";
 import LoadingSpinner from "./components/LoadingSpinner";
+import GenericSpinner from "./components/GenericSpinner";
 import DietForm from "./components/DietForm";
 import DietResults from "./components/DietResults";
 
@@ -166,7 +167,7 @@ function App() {
   if (authLoading) {
     return (
       <div className="flex justify-center items-center h-screen">
-        <LoadingSpinner />
+        <GenericSpinner />
       </div>
     );
   }

--- a/frontend/src/components/GenericSpinner.jsx
+++ b/frontend/src/components/GenericSpinner.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const GenericSpinner = () => (
+  <div className="flex items-center justify-center w-full h-full p-4">
+    <svg
+      className="animate-spin h-10 w-10 text-primary-600"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  </div>
+);
+
+export default GenericSpinner;


### PR DESCRIPTION
## Summary
- add a simple `GenericSpinner` component
- use it during authentication loading

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce715f0b0832cb595aa11ebefdeb5